### PR TITLE
update coreum testnet version

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -6,9 +6,9 @@
     coreum_user: "coreum"
     coreum_chain_id: "coreum-testnet-1"
     coreum_denom: "utestcore"
-    coreum_version: "v4.1.2"
+    coreum_version: "v5.0.0"
     cosmovisor_version: "v1.5.0"
-    upgrade_name: "v4patch2"
+    upgrade_name: "v5"
     moniker: "full"
     external_ip: "{{ ansible_host }}"
 


### PR DESCRIPTION
📝 Description:

- Following PR updates the `coreum-testnet-1` binary version to `v5.0.0` which was initiated by [Proposal 61](https://explorer.testnet-1.coreum.dev/coreum/proposals/61) 
- `ansible/playbook.yml` - binary version and upgrade plan name directory was also updated based on the [Coreum Official Instructions Page](https://docs.coreum.dev/docs/next/nodes-and-validators/upgrades/upgrades-instructions)